### PR TITLE
Add GitHub Actions deploy workflow (agent-triggerable deploys)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,93 @@
+name: Deploy
+
+# Manual trigger so production deploys are always intentional. Once this file is on
+# the default branch, a deploy can be started from the GitHub Actions UI or via the
+# API (which is how Claude Code triggers it). To auto-deploy on every merge to main,
+# add a `push: { branches: [main] }` trigger below.
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE: ghcr.io/wmichelin/pantry:latest
+      DOMAIN: pantry.waltermichelin.com
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push web image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.IMAGE }}
+          build-args: |
+            EXPO_PUBLIC_SUPABASE_URL=${{ secrets.EXPO_PUBLIC_SUPABASE_URL }}
+            EXPO_PUBLIC_SUPABASE_ANON_KEY=${{ secrets.EXPO_PUBLIC_SUPABASE_ANON_KEY }}
+
+      - name: Deploy on droplet
+        uses: appleboy/ssh-action@v1.2.0
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          host: ${{ secrets.DROPLET_HOST }}
+          username: root
+          key: ${{ secrets.DROPLET_SSH_KEY }}
+          envs: IMAGE,DOMAIN,GHCR_USER,GHCR_TOKEN
+          script_stop: true
+          script: |
+            set -e
+            # Install Docker if missing
+            if ! command -v docker >/dev/null 2>&1; then
+              apt-get update -y && apt-get install -y docker.io
+              systemctl enable docker && systemctl start docker
+            fi
+            # Install nginx + certbot if missing
+            if ! command -v nginx >/dev/null 2>&1; then
+              apt-get update -y && apt-get install -y nginx certbot python3-certbot-nginx
+            fi
+            # Pull and run the app container on 8080
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+            docker pull "$IMAGE"
+            docker rm -f pantry 2>/dev/null || true
+            docker run -d --name pantry --restart always -p 8080:80 "$IMAGE"
+            docker image prune -f || true
+            # Nginx + TLS: first deploy writes HTTP then runs certbot; afterwards just reload.
+            if [ ! -f "/etc/letsencrypt/live/$DOMAIN/fullchain.pem" ]; then
+              cat > /etc/nginx/sites-available/$DOMAIN <<NGINXCONF
+            server {
+                listen 80;
+                server_name $DOMAIN;
+                location / {
+                    proxy_pass http://localhost:8080;
+                    proxy_set_header Host \$host;
+                    proxy_set_header X-Real-IP \$remote_addr;
+                }
+            }
+            NGINXCONF
+              ln -sf /etc/nginx/sites-available/$DOMAIN /etc/nginx/sites-enabled/$DOMAIN
+              rm -f /etc/nginx/sites-enabled/default
+              nginx -t && systemctl reload nginx
+              certbot --nginx -d $DOMAIN --non-interactive --agree-tos -m wmichelin@gmail.com --redirect
+            else
+              nginx -t && systemctl reload nginx
+            fi

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,54 @@
+# Deployment
+
+Two ways to deploy the static web build to the DigitalOcean droplet
+(`pantry.waltermichelin.com`):
+
+1. **`./deploy.sh`** — runs from your laptop using your local `.env`, SSH key, and
+   `terraform/` state. Unchanged; still works.
+2. **GitHub Actions `Deploy` workflow** (`.github/workflows/deploy.yml`) — runs on
+   GitHub's runners using repo **secrets**, so it can be triggered without your
+   laptop. This is how Claude Code can deploy: it has no droplet access or secrets
+   in its sandbox, but it can start this workflow via the GitHub API.
+
+Both build the same image (`ghcr.io/wmichelin/pantry:latest`) and restart the
+`pantry` container on the droplet, mirroring `deploy.sh`.
+
+## One-time setup: add repo secrets
+
+In GitHub → **Settings → Secrets and variables → Actions → New repository secret**,
+add these four. (GHCR auth uses the built-in `GITHUB_TOKEN`, so no registry secret
+is needed.)
+
+| Secret | Value |
+|---|---|
+| `EXPO_PUBLIC_SUPABASE_URL` | Supabase project URL (baked into the web bundle at build time) |
+| `EXPO_PUBLIC_SUPABASE_ANON_KEY` | Supabase anon key |
+| `DROPLET_HOST` | The droplet's public IP (same value as `terraform output -raw droplet_ip`) |
+| `DROPLET_SSH_KEY` | A **private** SSH key whose public half is authorized for `root` on the droplet (paste the full key, including the BEGIN/END lines) |
+
+Notes:
+- The values for the two `EXPO_PUBLIC_*` secrets are the same ones in your local
+  `.env`. They are **public** by design (anon key + URL ship to the browser), but
+  storing them as secrets keeps the workflow file clean.
+- The droplet pulls the private GHCR image using the workflow's `GITHUB_TOKEN`, so
+  no Personal Access Token is required on the droplet.
+- `permissions: packages: write` in the workflow lets the runner push the image.
+
+## How to deploy
+
+- **From the GitHub UI:** Actions → **Deploy** → **Run workflow** → branch `main`.
+- **Via Claude Code:** ask it to deploy; it triggers the `Deploy` workflow on `main`
+  through the GitHub API and reports the run status. (The workflow must already be
+  merged to `main` — `workflow_dispatch` only triggers workflows on the default
+  branch.)
+
+The workflow is **manual-only** (`workflow_dispatch`) so deploys are always
+intentional. To auto-deploy on every merge to `main`, add a `push: { branches:
+[main] }` trigger to `deploy.yml`.
+
+## First run vs. subsequent runs
+
+On the very first run for a fresh droplet the workflow writes the nginx vhost and
+provisions a Let's Encrypt cert via certbot. Once `/etc/letsencrypt/live/$DOMAIN`
+exists, later runs skip that and only `nginx -t && systemctl reload nginx`, so they
+never clobber the HTTPS config.


### PR DESCRIPTION
## Summary

Adds a **GitHub Actions deploy workflow** so deploys can run without a developer laptop — secrets live in GitHub, and the workflow can be triggered from the Actions UI or via the API (which is how Claude Code can deploy). It mirrors `deploy.sh`.

## What it does (`.github/workflows/deploy.yml`)
- Builds the web image with the Supabase build args, pushes to `ghcr.io/wmichelin/pantry:latest` (GHCR auth via the built-in `GITHUB_TOKEN`).
- SSHes to the droplet, pulls + restarts the `pantry` container, and provisions nginx/TLS **only on first run** (subsequent runs just reload nginx, never clobbering HTTPS).
- **Manual trigger only** (`workflow_dispatch`) so deploys stay intentional.

## Required setup (you, one-time)
`workflow_dispatch` only triggers workflows on the **default branch**, so this must be merged to `main` before it can be run. Then add 4 repo secrets (Settings → Secrets and variables → Actions):

| Secret | Value |
|---|---|
| `EXPO_PUBLIC_SUPABASE_URL` | from your local `.env` |
| `EXPO_PUBLIC_SUPABASE_ANON_KEY` | from your local `.env` |
| `DROPLET_HOST` | droplet IP (`terraform output -raw droplet_ip`) |
| `DROPLET_SSH_KEY` | private SSH key authorized for `root` on the droplet |

`docs/DEPLOY.md` has the full walkthrough.

## After merge + secrets
I can trigger **Actions → Deploy** on `main` via the API and report the run status — that's the "deploy access" without putting any droplet secrets in my sandbox. `deploy.sh` still works from your laptop too.

https://claude.ai/code/session_01BtoVG5ST9ypQKUDZfceGDV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtoVG5ST9ypQKUDZfceGDV)_